### PR TITLE
improves characters without all orders

### DIFF
--- a/main/java/org/joverseer/ui/listviews/OrderEditorListView.java
+++ b/main/java/org/joverseer/ui/listviews/OrderEditorListView.java
@@ -257,17 +257,20 @@ public class OrderEditorListView extends ItemListView {
 
 			@Override
 			public boolean acceptCharacter(Character c) {
-				return c.getDeathReason().equals(CharacterDeathReasonEnum.NotDead) && c.getX() > 0 && (!c.getOrders()[0].isBlank() || !c.getOrders()[1].isBlank());
+				return c.getDeathReason().equals(CharacterDeathReasonEnum.NotDead) && c.getX() > 0 && (!c.getOrders()[0].isBlank() || !c.getOrders()[1].isBlank()|| !c.getOrders()[2].isBlank());
 			}
 		};
 		filterList.add(f);
 
 
-                 OrderFilter f = new OrderFilter("All characters without orders") {
+                 OrderFilter f = new OrderFilter("Characters without all orders") {
 
 			@Override
 			public boolean acceptCharacter(Character c) {
-				return c.getDeathReason().equals(CharacterDeathReasonEnum.NotDead) && c.getX() > 0 && (c.getOrders()[0].isBlank() || c.getOrders()[1].isBlank());
+				if (!GameHolder.hasInitializedGame())
+					return false;
+				PlayerInfo pi = (PlayerInfo) GameHolder.instance().getGame().getTurn().getContainer(TurnElementsEnum.PlayerInfo).findFirstByProperty("nationNo", c.getNationNo());
+				return pi != null && c.getDeathReason().equals(CharacterDeathReasonEnum.NotDead) && c.getX() > 0 && (c.getOrders()[0].isBlank() || c.getOrders()[1].isBlank()|| !c.getOrders()[2].isBlank());
 			}
 		};
 		filterList.add(f);


### PR DESCRIPTION
This uses the check from 'all imported' and adds that as a restriction -
meaning you don't get offered foreign characters and dragons in the
orders list view when this is selected