### PR TITLE
fixes #624

### DIFF
--- a/jOverseerRelease/src/jOverseerLauncher.xml
+++ b/jOverseerRelease/src/jOverseerLauncher.xml
@@ -19,6 +19,7 @@
     <maxVersion></maxVersion>
     <jdkPreference>preferJre</jdkPreference>
     <maxHeapSize>512</maxHeapSize>
+    <opt>-Djava.net.preferIPv4Stack=true</opt>
   </jre>
   <versionInfo>
     <fileVersion>1.0.0.0</fileVersion>

--- a/jOverseerRelease/src/joverseer.bat
+++ b/jOverseerRelease/src/joverseer.bat
@@ -1,2 +1,2 @@
 cd /d %~dp0
-java -Xmx512M -jar joverseer.jar %1
+java -Xmx512M -jar joverseer.jar -Djava.net.preferIPv4Stack=true %1

--- a/jOverseerRelease/src/unix-laucher.sh
+++ b/jOverseerRelease/src/unix-laucher.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 cd /joverseer
-java -Xmx384M -jar joverseer.jar
+java -Xmx512M -jar joverseer.jar -Djava.net.preferIPv4Stack=true


### PR DESCRIPTION
version 1.8 of java, selects IPv6 networking my default, which breaks
email sending.
This just explicitly sets the options for IPv4