### PR TITLE
reset the hexes in the game at creation time.

### DIFF
--- a/joverseerjar/src/org/joverseer/ui/command/CreateGame.java
+++ b/joverseerjar/src/org/joverseer/ui/command/CreateGame.java
@@ -48,6 +48,7 @@ public class CreateGame extends ActionCommand {
                 form.commit();
                 Game game = new Game();
                 GameMetadata gm = (GameMetadata)Application.instance().getApplicationContext().getBean("gameMetadata");
+                gm.getHexes().clear(); // without this the number of hexes keeps accumulating!
                 gm.setGame(game);
                 gm.setGameNo(ng.getNumber());
                 gm.setNationNo(ng.getNationNo());


### PR DESCRIPTION
this fixes #622 . The bug effectively corrupts the .jov file, so you need to delete and re-import to see the desired effects.