### PR TITLE
trim the char id

### DIFF
--- a/joverseerjar/src/org/joverseer/support/readers/newXml/CharacterMessageWrapper.java
+++ b/joverseerjar/src/org/joverseer/support/readers/newXml/CharacterMessageWrapper.java
@@ -37,7 +37,7 @@ public class CharacterMessageWrapper {
 	}
 
 	public void setCharId(String charId) {
-		this.charId = charId;
+		this.charId =  charId.trim(); //for those pesk ids less than 5 characters
 	}
 
 	public ArrayList<String> getLines() {


### PR DESCRIPTION
fix the character results import. it was importing with padding which
hashed to a different entry in the container.
..jov files will need to be recreated to see the change :(