### PR TITLE
# WARNING: head commit changed in the meantime

### DIFF
--- a/jOverseerRelease/build.xml
+++ b/jOverseerRelease/build.xml
@@ -11,6 +11,7 @@
     <property name="joverseer.jar">../joverseerjar/dist/lib/joverseer.jar</property>
 	<property name="updater.jar">../joverseerupdaterjar/dist/lib/update.jar</property>
 	<property name="res.dir">../joverseerjar/resources</property>
+	<property name="compat.rt.jar">${shared.lib}/compat-1.6-rt.jar</property>
     
     <property name="launch4j.dir" location="../launch4j"/>
     <!-- /beans/bean[@id='applicationDescriptor']/property[@name='version'].@value -->
@@ -105,7 +106,7 @@
        <echo message="Build finished."/>
    </target>
    <target name="JoverseerJar"
-       depends="-Init"
+       depends="-Init,versionLabel"
        description="use output from jOverseerJar">
    		<copy file="${joverseer.jar}" todir="${dist}"/>
    		<copy file="${res.dir}/layout/default.layout" todir="${dist}"/>
@@ -113,36 +114,9 @@
    </target>
 	
 	<target name="UpdateJar"
-		depends="-Init"
+		depends="-Init,versionLabel"
 		description="use output from joverseerupdaterjar">
 		<copy file="${updater.jar}" todir="${dist}"/>
-	</target>
-	<target name="Jar"
-		depends="-Init,JoverseerJar">
-		<jar destfile="${jarfile}"
-			basedir="${bin}"
-            excludes="**/JOverseerUserGuide.ppt,images/map/map.png,**/Thumbs.db,feed.xml,joverseerpackageant.xml,feed.xml,jOverseerLauncher.xml,Releasing.txt">
-            <manifest>
-                <attribute name="Main-Class" value="org.joverseer.ui.JOverseerJIDEClient"/>
-                <attribute name="Class-Path" value=". spring-beans.jar spring-binding-1.0.5.jar spring-context.jar spring-context-support.jar spring-core.jar spring-richclient-full-1.0.0.jar swingx-0.8.0.jar jide-action.jar jide-beaninfo.jar jide-common-patched.jar jide-components.jar jide-dialogs.jar jide-dock.jar jide-grids.jar FontBox-0.1.0-dev.jar PDFBox-0.7.3.jar commons-httpclient-3.0.1.jar looks-2.0.4.jar forms-1.0.7.jar log4j-1.2.12.jar commons-logging-1.1.jar commons-beanutils-1.7.0.jar commons-collections-3.1.jar junit-3.8.1.jar commons-digester-1.7.jar jdom.jar scope-bin.jar commons-codec-1.3.jar skinlf-1.2.11.jar"/>
-            </manifest>
-	    	<fileset dir="." includes="*.ver"/>
-	    	<!-- add images for joverseer -->
-	    	<fileset dir="${res.dir}"
-		   		includes="images/**"
-		     	excludes="images/map/map.png,**/Thumbs.db"/>
-	    	<!-- add jide/spring context/configuration -->
-	    	<fileset dir="${res.dir}"
-		    	includes="ctx/**"
-		     	excludes="ctx/*.out.xml"/>
-	    	<!-- add megames game metadata -->
-	    	<fileset dir="${res.dir}"
-		    	includes="metadata/**"
-		    	excludes="**/*.bak"/>
-	    	<!-- add UI read-only configuration and I18N messages -->
-	    	<fileset dir="${res.dir}"
-		    	includes="ui/**, tips.properties,log4j.properties"/>
-		</jar>
 	</target>
 	<target name="versionLabel">
 		<delete file="*.ver"/>

--- a/jOverseerRelease/src/joverseer.iss
+++ b/jOverseerRelease/src/joverseer.iss
@@ -2,6 +2,9 @@
 AppCopyright=Marios Skounakis
 AppName=JOverseer
 AppVerName=JOverseer
+AppVersion=@version@
+AppPublisher=Middle-Earth Games
+AppPublisherURL=http://www.middleearthgames.com
 DefaultDirName={pf}\JOverseer\
 DefaultGroupName=JOverseer
 OutputBaseFilename=joverseer-setup-@version@
@@ -59,4 +62,10 @@ Name: {app}\layout
 ;check that these are actually needed here...they used to be copied in 1.0.12
 Name: {app}\update
 
+[UninstallDelete]
+Type: files; Name: "{app}\update\update\update.jar"
+Type: files; Name: "{app}\update\update.jar"
+Type: dirifempty; Name: "{app}\update\update"
+Type: dirifempty; Name: "{app}\update"
+Type: dirifempty; Name: "{app}"
 

--- a/jOverseerRelease/src/testfeed.xml
+++ b/jOverseerRelease/src/testfeed.xml
@@ -6,8 +6,8 @@
     <description>The latest version of jOverseer, the Middle-Earth game helper program.</description>
     <language>en</language>
     <item>
-    <title>1.15.9</title>
-      <pubDate>Wed, 19 Apr 2017</pubDate>
+    <title>1.16.4</title>
+      <pubDate>Fri, 25 May 2018</pubDate>
       <description>
 VERSION 1.15.5
 --------------

--- a/joverseerjar/build.xml
+++ b/joverseerjar/build.xml
@@ -12,6 +12,7 @@
 	<property name="shared.lib">../lib</property>
     <property name="jardir">${dist}/lib</property>
     <property name="jarfile">${jardir}/joverseer.jar</property>
+	<property name="compat.rt.jar">${shared.lib}/compat-1.6-rt.jar</property>
     
     <!-- required projects -->
     <property name="updater.dir">../joverseerupdaterjar/dist/lib</property>
@@ -75,10 +76,9 @@
    <target name="Compile"
        depends="-Init"
        description="Compile all java classes">
-       <!-- encoding needed for
-       org.joverseer.support.AsciiUtils  -->
+       <!-- encoding needed for org.joverseer.support.AsciiUtils  -->
        <javac srcdir="${src}" destdir="${bin}" 
-           encoding="utf-8" includeantruntime="false" target="1.7" source="1.7">
+           encoding="utf-8" includeantruntime="false" source="1.6" target="1.6" bootclasspath="${compat.rt.jar}">
        		<classpath>
        			<pathelement path="${java.class.path}"/>
        			<path refid="updater.path"/>
@@ -126,6 +126,14 @@
             <manifest>
                 <attribute name="Main-Class" value="org.joverseer.ui.JOverseerJIDEClient"/>
                 <attribute name="Class-Path" value=". update.jar txt2xml.jar orderchecker.jar spring-beans.jar spring-binding-1.0.5.jar spring-context.jar spring-context-support.jar spring-core.jar spring-richclient-full-1.0.0.jar swingx-0.8.0.jar jide-action.jar jide-beaninfo.jar jide-common-patched.jar jide-components.jar jide-dialogs.jar jide-dock.jar jide-grids.jar FontBox-0.1.0-dev.jar PDFBox-0.7.3.jar commons-httpclient-3.0.1.jar looks-2.0.4.jar forms-1.0.7.jar log4j-1.2.12.jar commons-logging-1.1.jar commons-beanutils-1.7.0.jar commons-collections-3.1.jar junit-3.8.1.jar commons-digester-1.7.jar jdom.jar scope-bin.jar commons-codec-1.3.jar skinlf-1.2.11.jar"/>
+            	<section name="joverseer">
+            	    <attribute name="Specification-Title" value="JOverseer"/>
+            	    <attribute name="Specification-Version" value="${version}"/>
+            	    <attribute name="Specification-Vendor" value="Middle-Earth Games"/>
+            	    <attribute name="Implementation-Title" value="JOverseer"/>
+            	    <attribute name="Implementation-Version" value="${version} ${TODAY}"/>
+            	    <attribute name="Implementation-Vendor" value="Middle-Earth Games"/>
+            	</section>
             </manifest>
 	    	<fileset dir="${res.dir}"
 		    	includes="ctx/**"

--- a/joverseerjar/resources/ui/commands-context.xml
+++ b/joverseerjar/resources/ui/commands-context.xml
@@ -281,7 +281,7 @@
             	</bean>
                 <value>separator</value>
                 <bean class="org.joverseer.ui.command.EditPreferencesCommand">
-            		<property name="enabled"><value>false</value></property>
+            		<property name="enabled"><value>true</value></property>
             	</bean>
                 <bean class="org.joverseer.ui.command.PalantirStyleMapCommand">
             		<property name="enabled"><value>false</value></property>

--- a/joverseerupdaterjar/build.xml
+++ b/joverseerupdaterjar/build.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <project name="joverseerupdaterjar" default="BuildAll" basedir=".">
     <description>
         Build file for the updater.jar part of joverseer.
@@ -8,8 +8,10 @@
     <property name="dist">dist</property>
 	<property name="doc">${dist}/doc</property>
 	<property name="lib">lib</property>
+	<property name="shared.lib">../lib</property>
     <property name="jardir">${dist}/lib</property>
     <property name="jarfile">${jardir}/update.jar</property>
+	<property name="compat.rt.jar">${shared.lib}/compat-1.6-rt.jar</property>
 
     
    <!-- Main targets -->
@@ -21,7 +23,7 @@
    <target name="Compile"
        depends="-Init"
        description="Compile all java classes">
-       <javac srcdir="${src}" destdir="${bin}" includeantruntime="false" target="1.7" source="1.7">
+       <javac srcdir="${src}" destdir="${bin}" includeantruntime="false" source="1.6" target="1.6" bootclasspath="${compat.rt.jar}">
        		<classpath>
        			<pathelement path="${java.class.path}"/>
        		</classpath>

--- a/joverseerupdaterjar/src/com/middleearthgames/updater/Main_Gui.java
+++ b/joverseerupdaterjar/src/com/middleearthgames/updater/Main_Gui.java
@@ -63,7 +63,7 @@ public class Main_Gui extends JFrame{
 
      public Main_Gui(String downloadPath) {
         initComponents();
-        outText.setText("3 Contacting Download Server...");
+        outText.setText("Contacting Download Server...");
         this.downloadPath = downloadPath;
         download();
     }
@@ -80,6 +80,7 @@ public class Main_Gui extends JFrame{
         outText = new JTextArea();
         sp = new JScrollPane();
         sp.setViewportView(outText);
+        sp.setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED);
         
         if (System.getProperty("os.name").startsWith("Mac OS X")) {
         	launch = new JButton("Close and Launch App");
@@ -124,6 +125,7 @@ public class Main_Gui extends JFrame{
                     copyFiles(new File(root),new File("").getAbsolutePath());
                     cleanup(file);
                     launch.setEnabled(true);
+                    afterDownload();
                     logInfo("\nUpdate Finished!");
                 } catch (Exception ex) {
                 	logInfo("\n"+ex.getMessage());
@@ -294,6 +296,17 @@ public class Main_Gui extends JFrame{
     {
         this.outText.setText(this.outText.getText()+message);
     }
+    private void afterDownload()
+    {
+    	// do nothing for now but ideally load and run a routine from the downloaded version of update.jar.
+    	checkRequiredJavaVersion();
+    }
+    private void checkRequiredJavaVersion()
+    {
+    	if (getVersion() < 1.8 ) {
+    		JOptionPane.showMessageDialog(null, "Please update your version of java to at least version 1.8. See http://www.java.com");
+    	}
+    }
     public static void main(String args[]) {
     	String downloadPath = "http://www.middleearthgames.com/software/joverseer/url.html";
     	
@@ -316,5 +329,12 @@ public class Main_Gui extends JFrame{
     	runner = new UpdateRunnable(downloadPath);
         java.awt.EventQueue.invokeLater(runner);
     }
+    public static double JAVA_VERSION = getVersion ();
 
+    static double getVersion () {
+        String version = System.getProperty("java.version");
+        int pos = version.indexOf('.');
+        pos = version.indexOf('.', pos+1);
+        return Double.parseDouble (version.substring (0, pos));
+    }
 }

--- a/lib/.gitignore
+++ b/lib/.gitignore
@@ -1,0 +1,1 @@
+/compat-1.6-rt.jar

--- a/orderchecker/build.xml
+++ b/orderchecker/build.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <project name="orderchecker" default="BuildAll" basedir=".">
     <description>
         Build file for the orderchecker.jar part of joverseer.
@@ -8,8 +8,10 @@
     <property name="dist">dist</property>
 	<property name="doc">${dist}/doc</property>
 	<property name="lib">lib</property>
+	<property name="shared.lib">../lib</property>
     <property name="jardir">${dist}/lib</property>
     <property name="jarfile">${jardir}/orderchecker.jar</property>
+	<property name="compat.rt.jar">${shared.lib}/compat-1.6-rt.jar</property>
 
     
    <!-- Main targets -->
@@ -21,7 +23,7 @@
    <target name="Compile"
        depends="-Init"
        description="Compile all java classes">
-       <javac srcdir="${src}" destdir="${bin}" includeantruntime="false" target="1.7" source="1.7">
+       <javac srcdir="${src}" destdir="${bin}" includeantruntime="false" source="1.6" target="1.6" bootclasspath="${compat.rt.jar}">
        		<classpath>
        			<pathelement path="${java.class.path}"/>
        		</classpath>

--- a/txt2xmljar/build.xml
+++ b/txt2xmljar/build.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <project name="txt2xmljar" default="BuildAll" basedir=".">
     <description>
         Build file for the txt2xml.jar part of joverseer.
@@ -19,6 +19,7 @@
 	<property name="junit_path"> C:\Users\Dave\eclipse\mars\plugins\org.junit_4.12.0.v201504281640/junit.jar</property>
 	<property name="junit_deps_path">C:\Users\Dave\eclipse\mars\plugins/org.hamcrest.core_1.3.0.v201303031735.jar</property>
 	<property name="report.dir">${dist}/junitreport</property>
+	<property name="compat.rt.jar">${shared.lib}/compat-1.6-rt.jar</property>
 
     <path id="common.classpath">
     	<fileset dir="${shared.lib}" includes="**/*.jar"/>
@@ -26,6 +27,7 @@
     </path>
 	<path id="compiletime.classpath">
 	</path>
+	
 	
    <!-- Main targets -->
    <target name="BuildAll"
@@ -36,7 +38,7 @@
    <target name="Compile"
        depends="-Init"
        description="Compile all java classes">
-       <javac srcdir="${src}" destdir="${bin}" includeantruntime="false">
+       <javac srcdir="${src}" destdir="${bin}" includeantruntime="false" source="1.6" target="1.6" bootclasspath="${compat.rt.jar}">
     		<classpath>
     			<path refid="common.classpath"/>
 	   			<pathelement path="${java.class.path}"/>


### PR DESCRIPTION
remove java target version, CME fixes

Conflicts:

	joverseerjar/resources/metadata/CME.chars.csv

reinstate build against java 1.6 .
(developers will need to copy rt.jar from a 1.6 jre and put it into /lib
as compat-1.6-rt.jar to compile)

Code added so that future versions of the update will spot java versions
<1.8 and warn the user.

enables preferences menu even with no game loaded.