### PR TITLE
Apply Army size fix to all games

### DIFF
--- a/joverseerjar/src/org/joverseer/support/readers/xml/TurnXmlReader.java
+++ b/joverseerjar/src/org/joverseer/support/readers/xml/TurnXmlReader.java
@@ -485,11 +485,12 @@ public class TurnXmlReader implements Runnable {
 					// composition is reported, size is unknown
 					// and the army is reported again with size <> unknown but a
 					// larger InformationSource (i.e. less info)
-					//if (game.getMetadata().getGameType().equals(GameTypeEnum.gameKS)) {
+					// JDS - Now apply to all games
+
 						if (!a2.getSize().equals(ArmySizeEnum.unknown) && a1.getSize().equals(ArmySizeEnum.unknown)) {
 							a1.setSize(a2.getSize());
 						}
-					//}
+
 					updateWithInfo(a1, a2);
 				} else if (a2.getCommanderName().equals(UNKNOWN_MAP_ICON)) {
 					if (a1.getNationNo() > 0 && a2.getNationNo().equals(a1.getNationNo())) {

--- a/joverseerjar/src/org/joverseer/support/readers/xml/TurnXmlReader.java
+++ b/joverseerjar/src/org/joverseer/support/readers/xml/TurnXmlReader.java
@@ -485,11 +485,11 @@ public class TurnXmlReader implements Runnable {
 					// composition is reported, size is unknown
 					// and the army is reported again with size <> unknown but a
 					// larger InformationSource (i.e. less info)
-					if (game.getMetadata().getGameType().equals(GameTypeEnum.gameKS)) {
+					//if (game.getMetadata().getGameType().equals(GameTypeEnum.gameKS)) {
 						if (!a2.getSize().equals(ArmySizeEnum.unknown) && a1.getSize().equals(ArmySizeEnum.unknown)) {
 							a1.setSize(a2.getSize());
 						}
-					}
+					//}
 					updateWithInfo(a1, a2);
 				} else if (a2.getCommanderName().equals(UNKNOWN_MAP_ICON)) {
 					if (a1.getNationNo() > 0 && a2.getNationNo().equals(a1.getNationNo())) {


### PR DESCRIPTION
There was previously a fix in place to make sure army size estimates were available in KS. This is now needed to preserve army sizes in other games too. This removes the KS check so the fix is made to all games.